### PR TITLE
hotfix: first-deploy

### DIFF
--- a/src/app/work/discover-olvera/page.tsx
+++ b/src/app/work/discover-olvera/page.tsx
@@ -246,7 +246,7 @@ const discoverOlveraData = {
         ],
         images: [
             [
-                '/../../work/discover-olvera/team-photo.png',
+                '/../../static/images/team-photo.png',
                 'Team Photo',
                 'Tony, Erick, and I Discovering Olvera',
             ],


### PR DESCRIPTION
##What?
Did a fifth round of fixes for first deployment. None of the images on the Olvera page were displaying.
##How?
I put one of the images in a different folder, as recommended on [stack-overflow](https://stackoverflow.com/questions/73753354/images-arent-showing-in-vercel-deployment). We'll see how it works.